### PR TITLE
Add `yarn.lock` to `.npmignore`.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,3 +3,4 @@ src
 renovate.json
 .codeclimate.yml
 test
+yarn.lock


### PR DESCRIPTION
Alternatively, you could nix `.npmignore` and use the `files` field in `package.json`.